### PR TITLE
Add insights tab with mood analytics and advice

### DIFF
--- a/src/components/analytics/InsightsTab.tsx
+++ b/src/components/analytics/InsightsTab.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Constants, Enums } from "@/integrations/supabase/types";
+import { useMoodCountsAllTime } from "@/hooks/useSupabaseData";
+import { supabase } from "@/integrations/supabase/client";
+import { Brain, Sparkles } from "lucide-react";
+
+const MOOD_ADVICE: Record<Enums<'mood_type'>, string> = {
+  happy: "Keep reinforcing what works: note your gratitude and share moments with someone you care about.",
+  sad: "Be gentle with yourself. Try a short walk, a warm beverage, and reach out to a trusted person.",
+  angry: "Pause and reset. Practice box-breathing (4-4-4-4) and consider a brief physical activity to release tension.",
+  anxious: "Try a grounding technique (5-4-3-2-1), reduce caffeine, and schedule a small, achievable task.",
+  calm: "Protect the routines that bring calm—deep work blocks, mindful breaks, and consistent sleep.",
+  stressed: "Prioritize the top 1–2 tasks, take micro-breaks, and delegate or defer non-essentials.",
+  excited: "Channel the energy: capture ideas, pick one next action, and timebox a sprint to start.",
+  lonely: "Plan a social check-in, join a community or call a friend. Small connections matter.",
+  frustrated: "Break the blocker into smaller steps, reframe constraints, and celebrate small wins.",
+  motivated: "Leverage momentum—define a clear next step, set a timer, and protect the time to execute.",
+};
+
+export function InsightsTab() {
+  const { data: counts = [], refetch } = useMoodCountsAllTime();
+
+  useEffect(() => {
+    const channel = supabase
+      .channel('public:mood_entries')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'mood_entries' }, () => {
+        refetch();
+      })
+      .subscribe();
+    return () => {
+      try { supabase.removeChannel(channel); } catch {}
+    };
+  }, [refetch]);
+
+  const allMoods = Constants.public.Enums.mood_type as Enums<'mood_type'>[];
+  const byMood: Record<Enums<'mood_type'>, number> = useMemo(() => {
+    const map: Record<Enums<'mood_type'>, number> = Object.fromEntries(allMoods.map(m => [m, 0])) as Record<Enums<'mood_type'>, number>;
+    counts.forEach(({ mood, count }: { mood: Enums<'mood_type'>; count: number }) => {
+      map[mood] = (map[mood] ?? 0) + count;
+    });
+    return map;
+  }, [counts, allMoods]);
+
+  const { topMood, topCount } = useMemo(() => {
+    let best: Enums<'mood_type'> | null = null;
+    let bestCount = -1;
+    for (const m of allMoods) {
+      if (byMood[m] > bestCount) { best = m; bestCount = byMood[m]; }
+    }
+    return { topMood: best, topCount: bestCount } as { topMood: Enums<'mood_type'> | null; topCount: number };
+  }, [byMood, allMoods]);
+
+  return (
+    <div className="space-y-6 max-w-5xl mx-auto p-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold text-foreground flex items-center gap-2"><Brain className="w-7 h-7 text-primary"/> Insights</h1>
+        <p className="text-muted-foreground">Your mood patterns and personalized guidance</p>
+      </div>
+
+      <Card className="bg-gradient-card border-border shadow-soft">
+        <CardHeader>
+          <CardTitle className="text-foreground">Mood Log Counts</CardTitle>
+          <CardDescription>Number of times you've logged each mood</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+            {allMoods.map((mood) => (
+              <div key={mood} className="rounded-md border border-border/60 bg-card/60 p-3 flex items-center justify-between">
+                <span className="capitalize text-sm text-foreground">{mood}</span>
+                <Badge variant="outline" className="text-xs">{byMood[mood]}</Badge>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="bg-gradient-card border-border shadow-soft">
+        <CardHeader>
+          <CardTitle className="text-foreground flex items-center gap-2"><Sparkles className="w-5 h-5 text-accent"/> Personalized Insight</CardTitle>
+          <CardDescription>{topMood ? `Most frequent mood: ${topMood} (${topCount})` : "No mood entries yet"}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {topMood ? (
+            <p className="text-sm text-foreground leading-6">{MOOD_ADVICE[topMood]}</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">Start logging your mood to see tailored tips and trends.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -4,6 +4,7 @@ import { HomePage } from "../home/HomePage";
 import { ChatInterface } from "../chat/ChatInterface";
 import { AnalyticsDashboard } from "../analytics/AnalyticsDashboard";
 import { ProfilePage } from "../profile/ProfilePage";
+import { InsightsTab } from "../analytics/InsightsTab";
 import LiveBackground from "@/components/visual/LiveBackground";
 import type { Mood } from "../chat/ChatInterface";
 import { applyThemeForMood } from "@/lib/moodTheme";
@@ -44,6 +45,8 @@ export const MainLayout = () => {
         return <AnalyticsDashboard />;
       case "profile":
         return <ProfilePage />;
+      case "insights":
+        return <InsightsTab />;
       default:
         return <HomePage onNavigate={setActiveTab} />;
     }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Home, MessageCircle, User, BarChart3, Heart, LogOut } from "lucide-react";
+import { Home, MessageCircle, User, BarChart3, Heart, LogOut, Brain } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
@@ -14,6 +14,7 @@ const navigation = [
   { id: "chat", icon: MessageCircle, label: "Chat" },
   { id: "profile", icon: User, label: "Profile" },
   { id: "analytics", icon: BarChart3, label: "Analytics" },
+  { id: "insights", icon: Brain, label: "Insights" },
 ];
 
 export const Sidebar = ({ activeTab, onTabChange }: SidebarProps) => {

--- a/src/hooks/useSupabaseData.ts
+++ b/src/hooks/useSupabaseData.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getMyProfile, upsertMyProfile } from "@/integrations/supabase/repositories/profiles";
-import { addMoodEntry, listMoodEntriesLastNDays, getMoodDistributionForDate } from "@/integrations/supabase/repositories/moodEntries";
+import { addMoodEntry, listMoodEntriesLastNDays, getMoodDistributionForDate, getMoodCountsAllTime } from "@/integrations/supabase/repositories/moodEntries";
 import { addChatMessage, listChatMessages, clearChatMessages } from "@/integrations/supabase/repositories/chatMessages";
 import { upsertWellnessMetric, getLastNDaysWellness } from "@/integrations/supabase/repositories/wellnessMetrics";
 import type { Enums } from "@/integrations/supabase/types";
@@ -30,12 +30,17 @@ export function useAddMoodEntry() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["mood_entries"] });
       qc.invalidateQueries({ queryKey: ["mood_distribution"] });
+      qc.invalidateQueries({ queryKey: ["mood_counts_all_time"] });
     },
   });
 }
 
 export function useMoodDistribution(dateISO: string) {
   return useQuery({ queryKey: ["mood_distribution", dateISO], queryFn: () => getMoodDistributionForDate(dateISO), staleTime: 30_000 });
+}
+
+export function useMoodCountsAllTime() {
+  return useQuery({ queryKey: ["mood_counts_all_time"], queryFn: getMoodCountsAllTime, staleTime: 30_000 });
 }
 
 export function useChatMessages() {

--- a/src/integrations/supabase/repositories/moodEntries.ts
+++ b/src/integrations/supabase/repositories/moodEntries.ts
@@ -45,3 +45,15 @@ export async function getMoodDistributionForDate(dateISO: string) {
   data.forEach(r => counts.set(r.mood as Enums<'mood_type'>, (counts.get(r.mood as Enums<'mood_type'>) ?? 0) + 1));
   return Array.from(counts.entries()).map(([mood, count]) => ({ mood, count }));
 }
+
+export async function getMoodCountsAllTime() {
+  const user_id = await requireUserId();
+  const { data, error } = await supabase
+    .from("mood_entries")
+    .select("mood")
+    .eq("user_id", user_id);
+  if (error) throw error;
+  const counts = new Map<Enums<'mood_type'>, number>();
+  data.forEach(r => counts.set(r.mood as Enums<'mood_type'>, (counts.get(r.mood as Enums<'mood_type'>) ?? 0) + 1));
+  return Array.from(counts.entries()).map(([mood, count]) => ({ mood, count }));
+}


### PR DESCRIPTION
## Purpose

The user requested an insights tab that displays mood logging statistics and provides personalized advice based on the most frequently logged mood. This feature aims to help users understand their mood patterns and receive tailored guidance for emotional well-being.

## Code changes

- **Created `InsightsTab.tsx`**: New component that displays mood count statistics and personalized advice based on the most frequent mood
- **Added mood advice mapping**: Predefined advice for each mood type (happy, sad, angry, anxious, etc.)
- **Updated navigation**: Added "Insights" tab to sidebar with Brain icon
- **Enhanced data hooks**: Added `useMoodCountsAllTime()` hook for fetching all-time mood statistics
- **Added repository function**: `getMoodCountsAllTime()` to query mood entry counts across all time
- **Real-time updates**: Integrated Supabase real-time subscriptions to refresh data when mood entries change
- **Responsive design**: Grid layout for mood counts with proper styling and badgesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/33fdab2bdb784198a71b6e284d656d6d/pixel-works)

👀 [Preview Link](https://33fdab2bdb784198a71b6e284d656d6d-pixel-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>33fdab2bdb784198a71b6e284d656d6d</projectId>-->
<!--<branchName>pixel-works</branchName>-->